### PR TITLE
Cambios Necesarios:

### DIFF
--- a/src/simplecalc/Parser.java
+++ b/src/simplecalc/Parser.java
@@ -42,8 +42,8 @@ public class Parser {
         public String toString() {
             StringBuilder sb = new StringBuilder();
             sb.append("  Original (Infija): ").append(Parser.tokensToString(infixTokens)).append("\n"); 
-            sb.append("  Notación Postfija (Shunting-Yard): ").append(String.join(" ", postFixTokensString)).append("\n"); 
-            sb.append("  Simulación Pila (Infija a Postfija):\n");
+            sb.append("  Notación prefija: ").append(String.join(" ", postFixTokensString)).append("\n"); 
+            sb.append("  Simulación Pila (Infija a Prefija):\n");
             if (prefixStackSimulation.isEmpty()) { 
                 sb.append("    (No aplica para expresiones de un solo operando o sin operadores complejos)\n");
             } else {


### PR DESCRIPTION
Parser.java:
isOperator(Token.TokenType type): Modificar para que solo reconozca operadores aritméticos (+, -, *, /). hasOperators(List<Token> tokens): Se basará en el nuevo isOperator para detectar si una expresión tiene operadores aritméticos. collectExpression: Solo se llamará para expresiones que hasOperators detecte como verdaderas (es decir, que tengan operadores aritméticos). Las expresiones de un solo operando (ID, literal) o condiciones no serán recolectadas en este botón. generateQuadruples:
Los cuádruplos deben ser estrictamente para operaciones aritméticas. La salida del cuádruplo (tX = arg1 op arg2) que mencionaste es un formato diferente al op, arg1, arg2, result. Nos adaptaremos al formato result = arg1 op arg2 o similar para que sea más legible. Usaremos tX = arg1 op arg2 y si hay una asignación final variable = tX. checkTypeCompatibility: En las operaciones aritméticas, si el operador es + y los tipos son String, esto es una concatenación y se genera "String". Si se quiere excluir la concatenación de la generación de código intermedio (cuádruplos), entonces el collectExpression debe ser más selectivo. Por ahora, si expresion_aritmetica devuelve "String" para una suma, no la consideraremos para cuádruplos aritméticos.